### PR TITLE
[screensaver.pingpong] bump to 2.2.0

### DIFF
--- a/screensaver.pingpong/addon.xml.in
+++ b/screensaver.pingpong/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.pingpong"
-  version="2.1.1"
+  version="2.2.0"
   name="Ping Pong"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required