### PR TITLE
[Backport] Add missing cstddef includes

### DIFF
--- a/src/pingpong.cpp
+++ b/src/pingpong.cpp
@@ -24,6 +24,7 @@
 #include "main.h"
 #include "pingpong.h"
 
+#include <cstddef>
 #include <vector>
 
 #define NUMQUADS 3


### PR DESCRIPTION
Fixes build error with gcc 5.5.0.

Backported from https://github.com/xbmc/screensaver.pingpong/pull/21