### PR TITLE
[Leia] fix standalone build with newer glm versions (>= 0.9.9.6)

### DIFF
--- a/Findglm.cmake
+++ b/Findglm.cmake
@@ -1,0 +1,25 @@
+#.rst:
+# Findglm
+# ------------
+# Finds the OpenGL Mathematics (GLM) as a header only C++ mathematics library.
+#
+# This will define the following variables:
+#
+# GLM_FOUND - system has OpenGLES
+# GLM_INCLUDE_DIR - the OpenGLES include directory
+#
+# Note: Install was removed from GLM on version 0.9.9.6.
+
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_GLM glm QUIET)
+endif()
+
+find_path(GLM_INCLUDE_DIR glm.hpp
+                          PATHS ${PC_GLM_INCLUDEDIR}
+                          PATH_SUFFIXES glm)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(glm REQUIRED_VARS GLM_INCLUDE_DIR)
+
+mark_as_advanced(GLM_INCLUDE_DIR)

--- a/screensaver.pingpong/addon.xml.in
+++ b/screensaver.pingpong/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.pingpong"
-  version="2.1.2"
+  version="2.1.3"
   name="Ping Pong"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
On GLM 0.9.9.6 they have removed for me not understandable reason the install on his cmake :roll_eyes:.

If now the addon becomes created as standalone (debian, gentoo... builds) the integated addon depends are not used and takes system installed ones, but as that there PkgConfig or cmake parts no more available, are them not found by `find_package(glm REQUIRED)`.

This add now a cmake find script about to allow further use of them.